### PR TITLE
FIx typo

### DIFF
--- a/src/main/java/me/cr7mbl3/packetlogger/modules/PacketLogger.java
+++ b/src/main/java/me/cr7mbl3/packetlogger/modules/PacketLogger.java
@@ -38,12 +38,12 @@ public class PacketLogger extends Module {
     );
 
     public PacketLogger() {
-        super(Categories.Misc, "packet-logger", "Logs specific packets to console");
+        super(Categories.Misc, "packet-logger", "Logs specific packets to console.");
     }
 
     @EventHandler(priority = EventPriority.HIGHEST + 1)
     private void onReceivePacket(PacketEvent.Receive event) {
-        if (s2cPackets.get().contains(event.packet.getClass())) log("incomming", event.packet);
+        if (s2cPackets.get().contains(event.packet.getClass())) log("incoming", event.packet);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)


### PR DESCRIPTION
also adds a period at the end of the module's description